### PR TITLE
Prevent record types being coerced to maps.

### DIFF
--- a/src/bardo/interpolate.cljc
+++ b/src/bardo/interpolate.cljc
@@ -124,6 +124,7 @@
       (fn [t]
         (let [v (intrpl t)]
           (match [t v]
+                 [_ (_ :guard record?)] v
                  [0 (_ :guard hash-map?)] (select-keys v (keys start))
                  [1 (_ :guard hash-map?)] (select-keys v (keys end))
                  [0 (_ :guard sequential?)] (vec (take (count start) v))


### PR DESCRIPTION
`wrap-size` treats custom records types as maps, pulling all keys out and interpolating between them, instead of calling the custom interpolator on the record type. This causes errors when trying to chain or build a pipeline over a custom type.
